### PR TITLE
fix: typos and broken links in SKILL.md and references

### DIFF
--- a/skills/vueuse-functions/SKILL.md
+++ b/skills/vueuse-functions/SKILL.md
@@ -43,11 +43,11 @@ IMPORTANT: Each function entry includes a short `Description` and a detailed `Re
 | [`useDebouncedRefHistory`](references/useDebouncedRefHistory.md) | Shorthand for `useRefHistory` with debounced filter | AUTO |
 | [`useLastChanged`](references/useLastChanged.md) | Records the timestamp of the last change | AUTO |
 | [`useLocalStorage`](references/useLocalStorage.md) | Reactive [LocalStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) | AUTO |
-| [`useManualRefHistory`](references/useManualRefHistory.md) | Manually track the change history of a ref when the using calls `commit()` | AUTO |
+| [`useManualRefHistory`](references/useManualRefHistory.md) | Manually track the change history of a ref when the user calls `commit()` | AUTO |
 | [`useRefHistory`](references/useRefHistory.md) | Track the change history of a ref | AUTO |
 | [`useSessionStorage`](references/useSessionStorage.md) | Reactive [SessionStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) | AUTO |
 | [`useStorage`](references/useStorage.md) | Create a reactive ref that can be used to access & modify [LocalStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) or [SessionStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) | AUTO |
-| [`useStorageAsync`](references/useStorageAsync.md) | Reactive Storage in with async support | AUTO |
+| [`useStorageAsync`](references/useStorageAsync.md) | Reactive Storage with async support | AUTO |
 | [`useThrottledRefHistory`](references/useThrottledRefHistory.md) | Shorthand for `useRefHistory` with throttled filter | AUTO |
 
 ### Elements
@@ -61,7 +61,7 @@ IMPORTANT: Each function entry includes a short `Description` and a detailed `Re
 | [`useElementBounding`](references/useElementBounding.md) | Reactive [bounding box](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect) of an HTML element | AUTO |
 | [`useElementSize`](references/useElementSize.md) | Reactive size of an HTML element | AUTO |
 | [`useElementVisibility`](references/useElementVisibility.md) | Tracks the visibility of an element within the viewport | AUTO |
-| [`useIntersectionObserver`](references/useIntersectionObserver.md) | Detects that a target element's visibility | AUTO |
+| [`useIntersectionObserver`](references/useIntersectionObserver.md) | Detects changes to a target element's visibility | AUTO |
 | [`useMouseInElement`](references/useMouseInElement.md) | Reactive mouse position related to an element | AUTO |
 | [`useMutationObserver`](references/useMutationObserver.md) | Watch for changes being made to the DOM tree | AUTO |
 | [`useParentElement`](references/useParentElement.md) | Get parent element of the given element | AUTO |
@@ -108,7 +108,7 @@ IMPORTANT: Each function entry includes a short `Description` and a detailed `Re
 | [`useScreenSafeArea`](references/useScreenSafeArea.md) | Reactive `env(safe-area-inset-*)` | AUTO |
 | [`useScriptTag`](references/useScriptTag.md) | Creates a script tag | AUTO |
 | [`useShare`](references/useShare.md) | Reactive [Web Share API](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share) | AUTO |
-| [`useSSRWidth`](references/useSSRWidth.md) | Used to set a global viewport width which will be used when rendering SSR components that rely on the viewport width like [`useMediaQuery`](../useMediaQuery/index.md) or [`useBreakpoints`](../useBreakpoints/index.md) | AUTO |
+| [`useSSRWidth`](references/useSSRWidth.md) | Used to set a global viewport width which will be used when rendering SSR components that rely on the viewport width like [`useMediaQuery`](references/useMediaQuery.md) or [`useBreakpoints`](references/useBreakpoints.md) | AUTO |
 | [`useStyleTag`](references/useStyleTag.md) | Inject reactive `style` element in head | AUTO |
 | [`useTextareaAutosize`](references/useTextareaAutosize.md) | Automatically update the height of a textarea depending on the content | AUTO |
 | [`useTextDirection`](references/useTextDirection.md) | Reactive [dir](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir) of the element's text | AUTO |
@@ -138,7 +138,7 @@ IMPORTANT: Each function entry includes a short `Description` and a detailed `Re
 | [`useElementByPoint`](references/useElementByPoint.md) | Reactive element by point | AUTO |
 | [`useElementHover`](references/useElementHover.md) | Reactive element's hover state | AUTO |
 | [`useFocus`](references/useFocus.md) | Reactive utility to track or set the focus state of a DOM element | AUTO |
-| [`useFocusWithin`](references/useFocusWithin.md) | Reactive utility to track if an element or one of its decendants has focus | AUTO |
+| [`useFocusWithin`](references/useFocusWithin.md) | Reactive utility to track if an element or one of its descendants has focus | AUTO |
 | [`useFps`](references/useFps.md) | Reactive FPS (frames per second) | AUTO |
 | [`useGeolocation`](references/useGeolocation.md) | Reactive [Geolocation API](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API) | AUTO |
 | [`useIdle`](references/useIdle.md) | Tracks whether the user is being inactive | AUTO |

--- a/skills/vueuse-functions/references/useFocusWithin.md
+++ b/skills/vueuse-functions/references/useFocusWithin.md
@@ -4,7 +4,7 @@ category: Sensors
 
 # useFocusWithin
 
-Reactive utility to track if an element or one of its decendants has focus. It is meant to match the behavior of the `:focus-within` CSS pseudo-class. A common use case would be on a form element to see if any of its inputs currently have focus.
+Reactive utility to track if an element or one of its descendants has focus. It is meant to match the behavior of the `:focus-within` CSS pseudo-class. A common use case would be on a form element to see if any of its inputs currently have focus.
 
 ## Basic Usage
 

--- a/skills/vueuse-functions/references/useIntersectionObserver.md
+++ b/skills/vueuse-functions/references/useIntersectionObserver.md
@@ -4,7 +4,7 @@ category: Elements
 
 # useIntersectionObserver
 
-Detects that a target element's visibility.
+Detects changes to a target element's visibility.
 
 ## Usage
 
@@ -99,7 +99,7 @@ export interface UseIntersectionObserverReturn extends Supportable, Pausable {
   stop: () => void
 }
 /**
- * Detects that a target element's visibility.
+ * Detects changes to a target element's visibility.
  *
  * @see https://vueuse.org/useIntersectionObserver
  * @param target

--- a/skills/vueuse-functions/references/useManualRefHistory.md
+++ b/skills/vueuse-functions/references/useManualRefHistory.md
@@ -5,7 +5,7 @@ related: useRefHistory
 
 # useManualRefHistory
 
-Manually track the change history of a ref when the using calls `commit()`, also provides undo and redo functionality
+Manually track the change history of a ref when the user calls `commit()`, also provides undo and redo functionality
 
 ## Usage
 

--- a/skills/vueuse-functions/references/useSSRWidth.md
+++ b/skills/vueuse-functions/references/useSSRWidth.md
@@ -4,7 +4,7 @@ category: Browser
 
 # useSSRWidth
 
-Used to set a global viewport width which will be used when rendering SSR components that rely on the viewport width like [`useMediaQuery`](../useMediaQuery/index.md) or [`useBreakpoints`](../useBreakpoints/index.md)
+Used to set a global viewport width which will be used when rendering SSR components that rely on the viewport width like [`useMediaQuery`](useMediaQuery.md) or [`useBreakpoints`](useBreakpoints.md)
 
 ## Usage
 

--- a/skills/vueuse-functions/references/useStorageAsync.md
+++ b/skills/vueuse-functions/references/useStorageAsync.md
@@ -4,7 +4,7 @@ category: State
 
 # useStorageAsync
 
-Reactive Storage in with async support.
+Reactive Storage with async support.
 
 ## Usage
 


### PR DESCRIPTION
## Description

Fixes several typos and broken relative links in the vueuse-functions skill.

### Changes

- **useManualRefHistory**: "when the using calls" → "when the user calls"
- **useFocusWithin**: "decendants" → "descendants"
- **useStorageAsync**: "Reactive Storage in with async support" → "Reactive Storage with async support"
- **useSSRWidth**: broken relative links `../useMediaQuery/index.md` and `../useBreakpoints/index.md` → correct paths
- **useIntersectionObserver**: "Detects that a target element's visibility" → "Detects changes to a target element's visibility"

Fixes applied in both `SKILL.md` and the corresponding reference docs.